### PR TITLE
OpenQasm Teleportation in chapter 4.1 

### DIFF
--- a/samples/OpenQASM/ch04_01_basic_teleportation.qasm
+++ b/samples/OpenQASM/ch04_01_basic_teleportation.qasm
@@ -26,17 +26,18 @@ t q[0];
 barrier q[0],q[1],q[2],q[3],q[4];
 
 // Step 3: Send
+cx q[0],q[2];
 h q[0];
-h q[2];
-cx q[2],q[0];
-h q[2];
-measure q[0] -> c[0];
-measure q[2] -> c[2];
-barrier q[3],q[4];
+barrier q[0],q[1],q[2],q[3],q[4];
 
 // Step 4: Receive
-x q[4];
-z q[4];
+cx q[2], q[4];
+cz q[0], q[4];
+barrier q[0],q[1],q[2],q[3],q[4];
+
+//step 3.5: Measure Qubits according to the deferred measurement principle
+measure q[0] -> c[0];
+measure q[2] -> c[2];
 barrier q[3],q[4];
 
 // Step 5: Verify
@@ -44,3 +45,4 @@ tdg q[4];
 h q[4];
 x q[4];
 measure q[4] -> c[4];
+


### PR DESCRIPTION
altered to match QCEngine code and allow execution on live IBM QPU according to deferred measurement principle.